### PR TITLE
Add option to use DogStatsD as telemetry provider

### DIFF
--- a/role_variables.md
+++ b/role_variables.md
@@ -972,6 +972,7 @@ available starting at Vault version 1.4.
 - If enabled, you must set at least one of the following parameters according to your telemetry provider:
   - *vault_statsite_address* with a format of "FQDN:PORT"
   - *vault_statsd_address* with a format of "FQDN:PORT"
+  - *vault_dogstatsd_address* with a format of "FQDN:PORT"
   - *vault_prometheus_retention_time* e.g: "30s" or "24h"
 - If enabled, optionally set *vault_telemetry_disable_hostname* to strip the hostname prefix from telemetry data
 - Default value: *false*

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -123,6 +123,9 @@ telemetry {
   {% if vault_statsd_address is defined %}
   statsd_address = "{{vault_statsd_address}}"
   {% endif -%}
+  {% if vault_dogstatsd_address is defined %}
+  dogstatsd_addr = "{{vault_dogstatsd_address}}"
+  {% endif -%}
   {% if vault_prometheus_retention_time is defined %}
   prometheus_retention_time = "{{ vault_prometheus_retention_time }}"
   {% endif -%}


### PR DESCRIPTION
Add a new variable, `vault_dogstatsd_address`, to use the DogStatsD telemetry provider. It's documented here: https://developer.hashicorp.com/vault/docs/configuration/telemetry#dogstatsd_addr

The PR also updates the role variable documentation section on telemetry.