### PR TITLE
fix: allow user defined tls variables to be set instead of hardcoded default values

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -330,8 +330,8 @@ vault_transit_key_name: 'autounseal'
 vault_transit_mount_path: "transit/"
 # vault_transit_namespace: ''
 vault_transit_tls_ca_cert_file: "{{ vault_tls_ca_file }}"
-vault_transit_tls_client_cert_file: "autounseal_client_cert.pem"
-vault_transit_tls_client_key_file: "autounseal_client_key.pem"
+vault_transit_tls_client_cert_file: "{{ vault_transit_tls_client_cert | default('autounseal_client_cert.pem', true) }}"
+vault_transit_tls_client_key_file: "{{ vault_transit_tls_client_key | default('autounseal_client_key.pem', true) }}"
 # vault_transit_tls_server_name: ''
 vault_transit_tls_skip_verify: "{{ lookup('env', 'VAULT_SKIP_VERIFY') | default('', false) }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -329,7 +329,7 @@ vault_transit_disable_renewal: false
 vault_transit_key_name: 'autounseal'
 vault_transit_mount_path: "transit/"
 # vault_transit_namespace: ''
-vault_transit_tls_ca_cert_file: "{{ vault_tls_ca_file }}"
+vault_transit_tls_ca_cert_file: "{{ vault_transit_tls_ca_cert_file | default(vault_tls_ca_file) }}"
 vault_transit_tls_client_cert_file: "{{ vault_transit_tls_client_cert | default('autounseal_client_cert.pem', true) }}"
 vault_transit_tls_client_key_file: "{{ vault_transit_tls_client_key | default('autounseal_client_key.pem', true) }}"
 # vault_transit_tls_server_name: ''


### PR DESCRIPTION
Currently using the role variables as such

```yml
vault_transit_tls_ca_cert: "vault-transit-ca-chain.crt"
vault_transit_tls_client_cert: "vault-autounseal.crt"
vault_transit_tls_client_key: "vault-autounseal.key"
```

Will totally ignore the values and will always yield the following config. the jinja template looks fine but the issue is that the variables are overridden by the defaults as you can see below

```hcl
seal "transit" {
  //... stuff here
  
  // TLS Configuration
  tls_ca_cert        = "/etc/vault.d/tls/supporting-ca-chain.crt"
  tls_client_cert    = "/etc/vault.d/tls/autounseal_client_cert.pem"
  tls_client_key     = "/etc/vault.d/tls/autounseal_client_key.pem"
}
```

This pr fixes this