### PR TITLE
docs: migrate RTD URLs to docs.ansible.com

### DIFF
--- a/examples/README_VAGRANT.md
+++ b/examples/README_VAGRANT.md
@@ -42,7 +42,7 @@ steps to get up and running:
 1. Install the following prerequisites:
   - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [Vagrant-libvirt](https://vagrant-libvirt.github.io/vagrant-libvirt/#installation)
   - [Vagrant](http://downloads.vagrantup.com/)
-  - [vagrant-hosts plugin](https://docs.ansible.com/ansible/latest/installation_guide/index.html).
+  - [vagrant-hosts plugin](https://docs.ansible.com/projects/ansible/latest/installation_guide/index.html).
 2. Edit `/etc/hosts` or use the included `bin/preinstall` script to add
    the following entries to your development system's `/etc/hosts` file:
   - `10.1.42.240 vault1.local vault1`


### PR DESCRIPTION
## Summary

This PR updates `readthedocs.io` URLs to their `docs.ansible.com` equivalents with proper anchor preservation.

## Changes (1 unique URLs, 1 files updated)

- https://docs.ansible.com/ansible/latest/installation_guide/index.html → https://docs.ansible.com/projects/ansible/latest/installation_guide/index.html

## Technical Details

- ✅ Anchor fragments preserved during URL transformations
- ✅ HTTP redirects followed to final destinations  
- ✅ URL validation completed before applying changes
- ✅ Configuration-driven URL mapping system

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>