### PR TITLE
fix: replace usage of deprecated apt-key usage (fixes #386)

### DIFF
--- a/molecule/debian-12/molecule.yml
+++ b/molecule/debian-12/molecule.yml
@@ -1,0 +1,18 @@
+---
+platforms:
+  - name: debian-12_repo
+    groups:
+      - vault_raft_servers
+    image: dokken/debian-12
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+
+provisioner:
+  inventory:
+    host_vars:
+      debian-12_repo:
+        vault_install_hashi_repo: true
+        vault_bin_path: /usr/bin
+        vault_group: vault

--- a/molecule/debian-13-enterprise/molecule.yml
+++ b/molecule/debian-13-enterprise/molecule.yml
@@ -1,0 +1,34 @@
+---
+platforms:
+  - name: debian-13
+    groups:
+      - vault_raft_servers
+    image: dokken/debian-13
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: debian-13_repo
+    groups:
+      - vault_raft_servers
+    image: dokken/debian-13
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+
+provisioner:
+  playbooks:
+    prepare: prepare.yml
+  inventory:
+    host_vars:
+      debian-13:
+        vault_disable_api_health_check: true
+        vault_enterprise: true
+        vault_install_hashi_repo: false
+      debian-13_repo:
+        vault_disable_api_health_check: true
+        vault_enterprise: true
+        vault_install_hashi_repo: true
+        vault_bin_path: /usr/bin
+        vault_group: vault

--- a/molecule/debian-13-enterprise/prepare.yml
+++ b/molecule/debian-13-enterprise/prepare.yml
@@ -1,5 +1,5 @@
 ---
-- name: Prepare
+- name: Prepare controlling host
   hosts: localhost
   connection: local
 
@@ -9,11 +9,18 @@
       block:
         - name: Install OS packages on controlling host
           when: ansible_distribution != 'MacOSX'
-          package:
+          ansible.builtin.package:
             name: unzip
           become: true
 
         - name: Install netaddr dependency on controlling host
-          pip:
+          ansible.builtin.pip:
             name: netaddr
           become: false
+
+- name: Prepare Debian
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Bootstrap Python
+      ansible.builtin.raw: "test -e /usr/bin/python || apt-get install --update python3 -y"

--- a/molecule/debian-13/molecule.yml
+++ b/molecule/debian-13/molecule.yml
@@ -1,0 +1,20 @@
+---
+platforms:
+  - name: debian-13_repo
+    groups:
+      - vault_raft_servers
+    image: dokken/debian-13
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+
+provisioner:
+  playbooks:
+    prepare: prepare.yml
+  inventory:
+    host_vars:
+      debian-13_repo:
+        vault_install_hashi_repo: true
+        vault_bin_path: /usr/bin
+        vault_group: vault

--- a/molecule/debian-13/prepare.yml
+++ b/molecule/debian-13/prepare.yml
@@ -1,5 +1,5 @@
 ---
-- name: Prepare
+- name: Prepare controlling host
   hosts: localhost
   connection: local
 
@@ -9,11 +9,18 @@
       block:
         - name: Install OS packages on controlling host
           when: ansible_distribution != 'MacOSX'
-          package:
+          ansible.builtin.package:
             name: unzip
           become: true
 
         - name: Install netaddr dependency on controlling host
-          pip:
+          ansible.builtin.pip:
             name: netaddr
           become: false
+
+- name: Prepare Debian
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Bootstrap Python
+      ansible.builtin.raw: "test -e /usr/bin/python || apt-get install --update python3 -y"

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -15,16 +15,25 @@
     - ansible_pkg_mgr in ['yum', 'dnf']
     - not vault_rhsm_repo_id
 
+- name: Make sure apt keyring directory exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  become: true
+  when: ansible_pkg_mgr == 'apt'
+
 - name: Add Vault/Hashicorp apt key
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: "{{ vault_repository_key_url }}"
-    state: present
+    dest: /etc/apt/keyrings/hashicorp-archive-keyring.asc
+    mode: '0644'
   become: true
   when: ansible_pkg_mgr == 'apt'
 
 - name: Add Vault/Hashicorp apt repo
   ansible.builtin.apt_repository:
-    repo: "deb {{ vault_repository_url }} {{ ansible_distribution_release }} main"
+    repo: "deb [signed-by=/etc/apt/keyrings/hashicorp-archive-keyring.asc] {{ vault_repository_url }} {{ ansible_distribution_release }} main"
     state: present
   become: true
   when: ansible_pkg_mgr == 'apt'


### PR DESCRIPTION
This is necessary for proper support of Debian >= 13 and Ubuntu >= 25.04, but doesn't hurt on older (supported) versions of thos OSes.

- [x] Molecule tests work?
