### PR TITLE
fix: added gpg for Debian derivates 

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,6 +5,7 @@ vault_os_packages:
   - git
   - unzip
   - acl
+  - gpg
 
 _vault_repository_url: "https://apt.releases.hashicorp.com"
 _vault_repository_key_url: "{{ _vault_repository_url }}/gpg"


### PR DESCRIPTION
...as it is required for apt repo key verification