### PR TITLE
fix: add become to create private tls directory

### DIFF
--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -14,6 +14,7 @@
     - tls
 
 - name: Create private TLS directory
+  become: true
   ansible.builtin.file:
     path: "{{ vault_tls_private_path }}"
     state: directory


### PR DESCRIPTION
Without the creation of the subdirectory will fail with harden_file_perms because vault_tls_certs_path is no longer writable to the Ansible user.

```yaml
---
- name: Configure Vault Server
  hosts: vault
  vars:
    vault_install_hashi_repo: true
    vault_raft_group_name: vault
    vault_tls_disable: false
    vault_tls_copy_keys: true
    vault_tls_cert_file: "..."
    vault_tls_cert_key: "..."

  roles:
    - name: ansible-vault
```


```bash
TASK [ansible-vault : Create private TLS directory] *****************************************************************************************************************************************************************
[ERROR]: Task failed: Module failed: There was an issue creating /opt/vault/tls/private as requested: [Errno 13] Permission denied: b'/opt/vault/tls/private'
```

```bash
[root@localhost ~]# ls -al /opt/vault/tls/
total 8
dr-xr-xr-x. 2 vault vault   36 Nov 27 20:48 .
drwxr-xr-x. 4 root  root    29 Nov 27 20:41 ..
-rw-------. 1 root  root  1850 Nov 27 20:48 tls.crt
-rw-------. 1 root  root  3272 Nov 27 20:48 tls.key
```