### PR TITLE
fix: convert vault_raft_cluster_members and rhsm_repo_id to work with ansible 12

### DIFF
--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -13,7 +13,7 @@
   become: true
   when:
     - ansible_pkg_mgr in ['yum', 'dnf']
-    - not vault_rhsm_repo_id
+    - vault_rhsm_repo_id is falsy
 
 - name: Make sure apt keyring directory exists
   ansible.builtin.file:
@@ -39,7 +39,7 @@
   when: ansible_pkg_mgr == 'apt'
 
 - name: Attach RHSM subscription / repo
-  when: (vault_rhsm_repo_id)
+  when: vault_rhsm_repo_id is truthy
   become: true
   block:
     - name: Check if Hashicorp/Vault RHSM repo subscription is enabled

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -28,7 +28,7 @@ storage "raft" {
   }
   {% endif %}
   {% if not vault_raft_cloud_auto_join_exclusive %}
-  {% for raft_peer in vault_raft_cluster_members | rejectattr('peer', 'equalto', inventory_hostname) %}
+  {% for raft_peer in vault_raft_cluster_members | from_yaml | rejectattr('peer', 'equalto', inventory_hostname) %}
     {% if not (vault_tls_disable | bool) and vault_tls_client_ca_file != "" %}
   retry_join {
     leader_api_addr = "{{ raft_peer.api_addr }}"


### PR DESCRIPTION
```bash
TASK [ansible-vault : Vault main configuration] *********************************************************************************************************************************************************************
[ERROR]: Task failed: object of type 'str' has no attribute 'peer'

Task failed.
Origin: /ansible/roles/ansible-vault/tasks/main.yml:151:3

149     - vault_gcs_copy_sa | bool
150
151 - name: Vault main configuration
      ^ column 3

<<< caused by >>>

object of type 'str' has no attribute 'peer'
Origin: ansible/roles/ansible-vault/templates/vault_main_configuration.hcl.j2

fatal: [vm-vault-01]: FAILED! => {"changed": false, "msg": "Task failed: object of type 'str' has no attribute 'peer'"}
```

I also tried to convert the type on variable definition, but I think the conversion now must be on access. But we can discuss how this could be achieved most elegantly.

The codebase must be full of these types of problems. But you only find them if you execute a specific logic branch/config. Maybe we should go through every task and decide on a common approach for the most typical cases.


For the rhsm_variable, I adapted the solution chosen for "vault_rhsm_subscription_name".