### PR TITLE
fix: only run cache update if we have packages to install

### DIFF
--- a/tasks/plugins/acme.yml
+++ b/tasks/plugins/acme.yml
@@ -10,15 +10,6 @@
     - name: Fetch acme vault plugin
       delegate_to: "{{ (vault_plugin_acme_install == 'local') | ternary('localhost', inventory_hostname) }}"
       block:
-        - name: Install dependencies
-          ansible.builtin.package:
-            name: "{{ vault_os_packages }}"
-            state: present
-          become: true
-          when:
-            - (vault_plugin_acme_install == 'remote')
-            - (vault_os_packages is defined) and (vault_os_packages | length > 0)
-
         - name: Create temporary directory for acme vault plugin
           ansible.builtin.file:
             path: "{{ (vault_plugin_acme_install == 'local') | ternary(vault_plugins_src_dir_local, vault_plugins_src_dir_remote) }}/acme"

--- a/tasks/preinstall.yml
+++ b/tasks/preinstall.yml
@@ -22,10 +22,11 @@
   ansible.builtin.package:
     update_cache: true
   tags: update_cache
+  when: vault_os_packages | default([]) | length > 0
 
 - name: OS packages
   become: true
   ansible.builtin.package:
     name: "{{ vault_os_packages }}"
     state: present
-  when: (vault_os_packages is defined) and (vault_os_packages | length > 0)
+  when: vault_os_packages | default([]) | length > 0

--- a/vars/Flatcar.yml
+++ b/vars/Flatcar.yml
@@ -1,8 +1,6 @@
 ---
 # File: vars/Flatcar.yml - Flatcar Linux vars for Vault
 
-vault_os_packages: []
-
 vault_systemd_unit_path: /etc/systemd/system
 
 vault_bin_path: /opt/bin


### PR DESCRIPTION
As an alternative to #399: Guard the package cache update with the same check we use to decide if we have packages to install. The later vault installation updates the cache anyways if a new repository is added to the package manager.


