### PR TITLE
fix: Jinja2 template for vault service systemd file - "vault_port" variable casting to int (fixes #405)

### DIFF
--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -21,9 +21,9 @@ PrivateDevices=yes
 SecureBits=keep-caps
 Capabilities=CAP_IPC_LOCK+ep
 {% if systemd_version.stdout is version('230', '>=') %}
-AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK {{ "CAP_NET_BIND_SERVICE" if vault_port < 1024 }}
+AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK {{ "CAP_NET_BIND_SERVICE" if vault_port|int < 1024 }}
 {% endif %}
-CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK {{ "CAP_NET_BIND_SERVICE" if vault_port < 1024 }}
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK {{ "CAP_NET_BIND_SERVICE" if vault_port|int < 1024 }}
 NoNewPrivileges=yes
 {% if vault_gcs_copy_sa and vault_gcs_credentials_src_file is defined and vault_gcs_credentials_dst_file|length -%}
 Environment=GOOGLE_APPLICATION_CREDENTIALS={{ vault_gcs_credentials_dst_file }}


### PR DESCRIPTION
Ensure the "vault_port" variable is cast to type int

Fix for "'<' not supported between instances of 'str' and 'int'" when it checks if "vault_port" is < 1024.

Resolves: https://github.com/ansible-community/ansible-vault/issues/405