### PR TITLE
feat: provide ability to configure missing mysql storage options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -206,6 +206,9 @@ vault_mysql_tls_ca_file: ""
 vault_mysql_max_parallel: ""
 vault_mysql_max_idle_connections: ""
 vault_mysql_max_connection_lifetime: ""
+vault_mysql_plaintext_connection_allowed: ""
+vault_mysql_ha_enabled: false
+vault_mysql_lock_table: ""
 
 # gcs storage settings
 vault_gcs_bucket: ""

--- a/templates/vault_backend_mysql.j2
+++ b/templates/vault_backend_mysql.j2
@@ -22,4 +22,13 @@ storage "mysql" {
   {% if vault_mysql_max_connection_lifetime is defined and vault_mysql_max_connection_lifetime|length -%}
   max_connection_lifetime = "{{ vault_mysql_max_connection_lifetime }}"
   {% endif -%}
+  {% if vault_mysql_plaintext_connection_allowed is defined and vault_mysql_plaintext_connection_allowed|length -%}
+  plaintext_connection_allowed = "{{ vault_mysql_plaintext_connection_allowed }}"
+  {% endif -%}
+  {% if vault_mysql_ha_enabled is defined and vault_mysql_ha_enabled|bool -%}
+  ha_enabled = "{{ vault_mysql_ha_enabled | bool | lower }}"
+  {% endif -%}
+  {% if vault_mysql_lock_table is defined and vault_mysql_lock_table|length -%}
+  lock_table = "{{ vault_mysql_lock_table }}"
+  {% endif -%}
 }


### PR DESCRIPTION
Seeing that the mysql storage should be able to provide HA support for vault, and us already having a fully redundant MariaDB Galera/Maxscale cluster setup available, I wanted to try using it with vault - but found that the "ha_enabled" option was missing from the ansible role.
Thus adding this and the rest of the documented but missing settings with this PR.
