### PR TITLE
fix: recursive definition caused by typo in vault_transit_tls_ca_cert

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -329,7 +329,7 @@ vault_transit_disable_renewal: false
 vault_transit_key_name: 'autounseal'
 vault_transit_mount_path: "transit/"
 # vault_transit_namespace: ''
-vault_transit_tls_ca_cert_file: "{{ vault_transit_tls_ca_cert_file | default(vault_tls_ca_file) }}"
+vault_transit_tls_ca_cert_file: "{{ vault_transit_tls_ca_cert | default(vault_tls_ca_file) }}"
 vault_transit_tls_client_cert_file: "{{ vault_transit_tls_client_cert | default('autounseal_client_cert.pem', true) }}"
 vault_transit_tls_client_key_file: "{{ vault_transit_tls_client_key | default('autounseal_client_key.pem', true) }}"
 # vault_transit_tls_server_name: ''


### PR DESCRIPTION
[defaults/main.yml](https://github.com/ansible-community/ansible-vault/blob/9a10574d2efb4ef7b07d3c51044f34a52c2af525/defaults/main.yml#L332) defines

```yml
vault_transit_tls_ca_cert_file: "{{ vault_transit_tls_ca_cert_file | default(vault_tls_ca_file) }}"
```

This is a typo, readme has documentation for `vault_transit_tls_ca_cert` variable