### PR TITLE
optionally do not use subshell for systemd execstart

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,7 @@ vault_enable_logrotate: false
 vault_logrotate_freq: 7
 vault_logrotate_template: vault_logrotate.j2
 vault_exec_output: ''
+vault_systemd_use_subshell: true
 
 # Handlers
 vault_service_restart: true

--- a/role_variables.md
+++ b/role_variables.md
@@ -198,6 +198,11 @@ The role defines variables in `defaults/main.yml`:
 - Enable vault web UI
 - Default value:  true
 
+## `vault_systemd_use_subshell`
+
+- When `true`, the systemd `ExecStart` wraps the vault command in `/bin/sh -c 'exec ...'`. When `false`, vault is launched directly, so systemd logs show `vault[PID]` instead of `sh[PID]`. Set to `false` if you want cleaner journal output. Note: disabling the subshell means shell expansion (e.g. glob patterns in `vault_exec_output`) will not be available.
+- Default value: true
+
 ## `vault_service_restart`
 
 - Should the playbook restart Vault service when needed

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -40,7 +40,11 @@ Environment=NO_PROXY={{ vault_no_proxy }}
 {% for _vault_variable_name, _vault_variable_value in vault_additional_environment_variables.items() -%}
 Environment={{ _vault_variable_name }}={{ _vault_variable_value }}
 {% endfor -%}
+{% if vault_systemd_use_subshell %}
 ExecStart=/bin/sh -c 'exec {{ vault_bin_path }}/vault server -config={{ vault_config_path if vault_use_config_path else vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}'
+{% else %}
+ExecStart={{ vault_bin_path }}/vault server -config={{ vault_config_path if vault_use_config_path else vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}
+{% endif %}
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 KillSignal=SIGINT


### PR DESCRIPTION
Closes: https://github.com/ansible-community/ansible-vault/issues/414

Maintains current behavior and allows for optional non-subshell deployment