### PR TITLE
Add retry logic to get_url tasks to handle transient network failures

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,6 +19,10 @@
     mode: "0644"
   become: "{{ vault_privileged_install }}"
   run_once: true
+  register: __vault_download_local_package
+  retries: 6
+  until: __vault_download_local_package is succeeded
+  delay: 10
   tags: installation
   when: not vault_package.stat.exists | bool
   delegate_to: 127.0.0.1

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -28,6 +28,10 @@
     url: "{{ vault_repository_key_url }}"
     dest: /etc/apt/keyrings/hashicorp-archive-keyring.asc
     mode: '0644'
+  register: __vault_hashicorp_apt_key_download
+  retries: 6
+  until: __vault_hashicorp_apt_key_download is succeeded
+  delay: 10
   become: true
   when: ansible_pkg_mgr == 'apt'
 

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -21,6 +21,10 @@
     checksum: "sha256:{{ (lookup('url', vault_checksum_file_url, wantlist=true) | select('match', '.*' + vault_pkg + '$') | first).split()[0] }}"
     timeout: 42
     mode: "0644"
+  register: __vault_download_remote_package
+  retries: 6
+  until: __vault_download_remote_package is succeeded
+  delay: 10
   tags: installation
   when: not vault_package.stat.exists | bool
 

--- a/tasks/plugins/acme.yml
+++ b/tasks/plugins/acme.yml
@@ -27,6 +27,9 @@
             checksum: "sha256:{{ vault_plugin_acme_zip_sha256sum }}"
             mode: "0644"
           register: __vault_plugin_acme_zip_file
+          retries: 6
+          until: __vault_plugin_acme_zip_file is succeeded
+          delay: 10
           run_once: "{{ (vault_plugin_acme_install == 'local') }}"
 
         - name: Extract acme vault plugin


### PR DESCRIPTION
**Summary**
This PR adds retry handling to all role download tasks using get_url so transient network hiccups don’t fail the playbook immediately.

**Motivation**
I hit intermittent network failures during playbook execution. Since get_url failed on first error, the run stopped even when a retry would likely succeed.

**Changes**
Added retry controls (register, until, retries, delay) to these tasks:

•  tasks/install.yml
•  tasks/install_remote.yml
•  tasks/install_hashi_repo.yml
•  tasks/plugins/acme.yml

Retry behavior is consistent with existing patterns in the role.

**Impact**
•  Improves resilience for temporary download/network issues.
•  No change to URLs, checksums, or install flow.
•  Tasks still fail normally after retry attempts are exhausted.

**Notes**
•  This is a reliability improvement only (no functional feature change).