### PR TITLE
fix: add become: true to task 'Update package cache'

### DIFF
--- a/tasks/preinstall.yml
+++ b/tasks/preinstall.yml
@@ -19,6 +19,7 @@
   when: vault_manage_user | bool
 
 - name: Update package cache
+  become: true
   ansible.builtin.package:
     update_cache: true
   tags: update_cache


### PR DESCRIPTION
Add become: true to the task 'Update package cache'

I got an error log when running Ansible.
```
TASK [../../../database/ansible-vault : Update package cache] *******************************************************************************************************************************************************************
fatal: [node2]: FAILED! => {"changed": false, "msg": "Failed to lock apt for exclusive operation: Failed to lock directory /var/lib/apt/lists/: E:Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)"}
```