### PR TITLE
feat: allow to configure `unauthenticated_metrics_access` for each tcp listener

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,7 +125,7 @@ vault_tcp_listeners:
     vault_tls_cipher_suites: '{{ vault_tls_cipher_suites }}'
     vault_tls_require_and_verify_client_cert: '{{ vault_tls_require_and_verify_client_cert }}'
     vault_tls_disable_client_certs: '{{ vault_tls_disable_client_certs }}'
-    vault_unauthenticated_metrics_access: '{{ vault_unauthenticated_metrics_access }}'
+    # vault_unauthenticated_metrics_access: '{{ vault_unauthenticated_metrics_access }}'
     # vault_x_forwarded_for_authorized_addrs: '{{ vault_x_forwarded_for_authorized_addrs }}'
     # vault_x_forwarded_for_hop_skips: '{{ vault_x_forwarded_for_hop_skips }}'
     # vault_x_forwarded_for_reject_not_authorized: '{{ vault_x_forwarded_for_reject_not_authorized }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,6 +125,7 @@ vault_tcp_listeners:
     vault_tls_cipher_suites: '{{ vault_tls_cipher_suites }}'
     vault_tls_require_and_verify_client_cert: '{{ vault_tls_require_and_verify_client_cert }}'
     vault_tls_disable_client_certs: '{{ vault_tls_disable_client_certs }}'
+    vault_unauthenticated_metrics_access: '{{ vault_unauthenticated_metrics_access }}'
     # vault_x_forwarded_for_authorized_addrs: '{{ vault_x_forwarded_for_authorized_addrs }}'
     # vault_x_forwarded_for_hop_skips: '{{ vault_x_forwarded_for_hop_skips }}'
     # vault_x_forwarded_for_reject_not_authorized: '{{ vault_x_forwarded_for_reject_not_authorized }}'

--- a/role_variables.md
+++ b/role_variables.md
@@ -267,7 +267,7 @@ vault_tcp_listeners:
     vault_tls_cipher_suites: '{{ vault_tls_cipher_suites }}'
     vault_tls_require_and_verify_client_cert: '{{ vault_tls_require_and_verify_client_cert }}'
     vault_tls_disable_client_certs: '{{ vault_tls_disable_client_certs }}'
-    vault_unauthenticated_metrics_access: '{{ vault_unauthenticated_metrics_access }}'
+    # vault_unauthenticated_metrics_access: '{{ vault_unauthenticated_metrics_access }}'
     # vault_x_forwarded_for_authorized_addrs: '{{ vault_x_forwarded_for_authorized_addrs }}'
     # vault_x_forwarded_for_hop_skips: '{{ vault_x_forwarded_for_hop_skips }}'
     # vault_x_forwarded_for_reject_not_authorized: '{{ vault_x_forwarded_for_reject_not_authorized }}'

--- a/role_variables.md
+++ b/role_variables.md
@@ -267,6 +267,7 @@ vault_tcp_listeners:
     vault_tls_cipher_suites: '{{ vault_tls_cipher_suites }}'
     vault_tls_require_and_verify_client_cert: '{{ vault_tls_require_and_verify_client_cert }}'
     vault_tls_disable_client_certs: '{{ vault_tls_disable_client_certs }}'
+    vault_unauthenticated_metrics_access: '{{ vault_unauthenticated_metrics_access }}'
     # vault_x_forwarded_for_authorized_addrs: '{{ vault_x_forwarded_for_authorized_addrs }}'
     # vault_x_forwarded_for_hop_skips: '{{ vault_x_forwarded_for_hop_skips }}'
     # vault_x_forwarded_for_reject_not_authorized: '{{ vault_x_forwarded_for_reject_not_authorized }}'
@@ -976,6 +977,7 @@ vault_additional_environment_variables:
 ## `vault_unauthenticated_metrics_access`
 
 - Configure [unauthenticated metrics access](https://www.vaultproject.io/docs/configuration/listener/tcp#configuring-unauthenticated-metrics-access)
+- Can also be set per listener in `vault_tcp_listeners`; a listener-level value overrides the global one
 - Default value: false
 
 ## `vault_telemetry_usage_gauge_period`

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -50,7 +50,7 @@ listener "tcp" {
   x_forwarded_for_reject_not_present = {{ l.vault_x_forwarded_for_reject_not_present | bool | lower }}
   {% endif -%}
   {% endif -%}
-  {% if (vault_unauthenticated_metrics_access | bool) -%}
+  {% if (l.vault_unauthenticated_metrics_access | default(vault_unauthenticated_metrics_access) | bool) -%}
   telemetry {
     unauthenticated_metrics_access = "true"
   }


### PR DESCRIPTION
Hi,
this small PR adds ability to configure `unauthenticated_metrics_access` for each TCP listener separately. This is useful when someone wants to expose vault directly on some TCP targets, but keep `unauthenticated_metrics_access` enabled only for local metrics collector (which should use different TCP listener, which listens only on localhost/internal network)